### PR TITLE
Fix linux builds

### DIFF
--- a/packages/noodl-editor/package.json
+++ b/packages/noodl-editor/package.json
@@ -18,6 +18,7 @@
     "appId": "com.opennoodl.app",
     "afterSign": "./build/macos-notarize.js",
     "mac": {
+      "category": "public.app-category.developer-tools"
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "extendInfo": {
@@ -34,6 +35,7 @@
     },
     "linux": {
       "target": "appimage"
+      "category": "Development"
     },
     "protocols": {
       "name": "opennoodl",

--- a/packages/noodl-editor/package.json
+++ b/packages/noodl-editor/package.json
@@ -33,7 +33,7 @@
       "guid": "com.opennoodl.app"
     },
     "linux": {
-      "target": "deb"
+      "target": "appimage"
     },
     "protocols": {
       "name": "opennoodl",

--- a/packages/noodl-editor/package.json
+++ b/packages/noodl-editor/package.json
@@ -18,7 +18,7 @@
     "appId": "com.opennoodl.app",
     "afterSign": "./build/macos-notarize.js",
     "mac": {
-      "category": "public.app-category.developer-tools"
+      "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "extendInfo": {
@@ -34,7 +34,7 @@
       "guid": "com.opennoodl.app"
     },
     "linux": {
-      "target": "appimage"
+      "target": "appimage",
       "category": "Development"
     },
     "protocols": {

--- a/packages/noodl-editor/scripts/build.ts
+++ b/packages/noodl-editor/scripts/build.ts
@@ -6,6 +6,7 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
 (async function () {
   // Inputs
   const DISABLE_SIGNING = valueToBoolean(process.env.DISABLE_SIGNING);
+  const BUILD_AS_DIR = valueToBoolean(process.env.BUILD_AS_DIR);
   const TARGET_PLATFORM = process.env.TARGET_PLATFORM;
 
   if (!TARGET_PLATFORM) throw new Error('TARGET_PLATFORM is falsy');
@@ -39,10 +40,14 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
   console.log('--- done!');
 
   const platformName = getDistPlatform(target.platform);
-  const args = [`--${platformName}`, `--${target.arch}`].join(' ');
+  let args = [`--${target.arch}`, `--${platformName}`];
+  if (BUILD_AS_DIR === true) {
+      args.push('--dir');
+  }
+  const argsStr = args.join(' ');
 
-  console.log(`--- Run: 'npx electron-builder ${args}' ...`);
-  execSync('npx electron-builder ' + args, {
+  console.log(`--- Run: 'npx electron-builder ${argsStr}' ...`);
+  execSync('npx electron-builder ' + argsStr, {
     stdio: [0, 1, 2],
     env: Object.assign(
       DISABLE_SIGNING

--- a/packages/noodl-editor/scripts/build.ts
+++ b/packages/noodl-editor/scripts/build.ts
@@ -20,6 +20,7 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
   console.log('@ -> packages/noodl-editor/scripts/build.ts');
   console.log('--- Configuration');
   console.log('> DISABLE_SIGNING: ', DISABLE_SIGNING);
+  console.log('> BUILD_AS_DIR: ', BUILD_AS_DIR);
   console.log('> TARGET_PLATFORM: ', TARGET_PLATFORM);
   console.log('---');
 

--- a/scripts/build-pack.ts
+++ b/scripts/build-pack.ts
@@ -52,7 +52,10 @@ const regexList: RegExp[] = [
 
   /* MacOS */
   /.*\.dmg$/,
-  /.*\.blockmap$/
+  /.*\.blockmap$/,
+
+  /* Linux */
+  /.*\.AppImage$/,
 ];
 
 fs.mkdirSync(destinationFolder, { recursive: true });


### PR DESCRIPTION
At this point the build script tries to build a deb which as we've grown to know is a terrible solution to application packaging. An AppImage that ships a single executable ready to go is a much better solution

I also added the `BUILD_AS_DIR` env var flag to be able to electron-build as an unpacked directory. This helps a lot in cases that you want to bring your own electron (for example in nixos I can't run dynamically linked binaries and it would require elf patching of its linked libraries, which is not fun) and introduces negligible no additional complexity to the build