### PR TITLE
Revert "Fix linux builds"

### DIFF
--- a/packages/noodl-editor/package.json
+++ b/packages/noodl-editor/package.json
@@ -18,7 +18,6 @@
     "appId": "com.opennoodl.app",
     "afterSign": "./build/macos-notarize.js",
     "mac": {
-      "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "extendInfo": {
@@ -34,8 +33,7 @@
       "guid": "com.opennoodl.app"
     },
     "linux": {
-      "target": "appimage",
-      "category": "Development"
+      "target": "deb"
     },
     "protocols": {
       "name": "opennoodl",

--- a/packages/noodl-editor/scripts/build.ts
+++ b/packages/noodl-editor/scripts/build.ts
@@ -6,7 +6,6 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
 (async function () {
   // Inputs
   const DISABLE_SIGNING = valueToBoolean(process.env.DISABLE_SIGNING);
-  const BUILD_AS_DIR = valueToBoolean(process.env.BUILD_AS_DIR);
   const TARGET_PLATFORM = process.env.TARGET_PLATFORM;
 
   if (!TARGET_PLATFORM) throw new Error('TARGET_PLATFORM is falsy');
@@ -20,7 +19,6 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
   console.log('@ -> packages/noodl-editor/scripts/build.ts');
   console.log('--- Configuration');
   console.log('> DISABLE_SIGNING: ', DISABLE_SIGNING);
-  console.log('> BUILD_AS_DIR: ', BUILD_AS_DIR);
   console.log('> TARGET_PLATFORM: ', TARGET_PLATFORM);
   console.log('---');
 
@@ -41,14 +39,10 @@ import { BuildTarget, getDistPlatform } from './platform/build-platforms';
   console.log('--- done!');
 
   const platformName = getDistPlatform(target.platform);
-  let args = [`--${target.arch}`, `--${platformName}`];
-  if (BUILD_AS_DIR === true) {
-      args.push('--dir');
-  }
-  const argsStr = args.join(' ');
+  const args = [`--${platformName}`, `--${target.arch}`].join(' ');
 
-  console.log(`--- Run: 'npx electron-builder ${argsStr}' ...`);
-  execSync('npx electron-builder ' + argsStr, {
+  console.log(`--- Run: 'npx electron-builder ${args}' ...`);
+  execSync('npx electron-builder ' + args, {
     stdio: [0, 1, 2],
     env: Object.assign(
       DISABLE_SIGNING

--- a/scripts/build-pack.ts
+++ b/scripts/build-pack.ts
@@ -52,10 +52,7 @@ const regexList: RegExp[] = [
 
   /* MacOS */
   /.*\.dmg$/,
-  /.*\.blockmap$/,
-
-  /* Linux */
-  /.*\.AppImage$/,
+  /.*\.blockmap$/
 ];
 
 fs.mkdirSync(destinationFolder, { recursive: true });


### PR DESCRIPTION
Reverts The-Low-Code-Foundation/OpenNoodl#6

Some concern in the community about the effect this will have on the current Arch Linux build. More research required.

« I am hoping that you will reverse the merge - any future builds will break on arch as well (as I am dependent on the Deb). Also you will not be able to have opennoodl *natively* on any Debian based system (the most common in the world) »