### PR TITLE
ci: put the nightly packaged build on main, pinned to cline-dev

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,100 @@
+name: Nightly packaged build
+
+# Unsigned packaged builds for all three platforms, so packaging breakage
+# surfaces within a day instead of at release time. Signing and publishing
+# arrive with REV-007; this job only proves electron-builder still produces an
+# installer.
+#
+# Deliberately not a PR gate: it wipes node_modules and reinstalls per target
+# architecture, which is far too slow (and too expensive on macOS/Windows
+# runners) to sit in front of every merge.
+#
+# ── Why this file lives on `main` but builds `cline-dev` ──────────────────────
+# GitHub only registers `schedule:` triggers from the repository's DEFAULT branch.
+# This workflow originally existed only on `cline-dev`, so its cron was never
+# registered and the nightly had never run once. The file therefore has to be on
+# `main`.
+#
+# But `actions/checkout` defaults to the branch the workflow ran from, and `main`
+# is far behind `cline-dev` — it does not even contain `.github/actions/setup`,
+# so a default checkout would fail at that step every night and prove nothing
+# except that the alarm works. The checkout is pinned to the development branch
+# instead: the schedule comes from `main`, the code under test comes from
+# `cline-dev`.
+#
+# Remove the pin when `cline-dev` merges to `main` (or `main` is retired).
+
+on:
+  schedule:
+    # 03:00 UTC daily.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or SHA to package (defaults to cline-dev)'
+        required: false
+        default: 'cline-dev'
+
+env:
+  # One place to change when the development branch is renamed or retired.
+  BUILD_REF: ${{ github.event.inputs.ref || 'cline-dev' }}
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x64
+          - os: windows-latest
+            platform: win32-x64
+          - os: macos-latest
+            platform: darwin-arm64
+          # macos-13 was retired by GitHub (Dec 2025); macos-15-intel is the
+          # supported Intel image (DEBT-007).
+          - os: macos-15-intel
+            platform: darwin-x64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BUILD_REF }}
+
+      # electron-builder shells out to python on some paths.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: ./.github/actions/setup
+
+      - name: Build viewer bundles
+        run: npm run build:editor:_viewer
+        env:
+          WORKSPACE_PATH: .
+
+      - name: Build and package the editor
+        run: npm run build:editor:_editor
+        env:
+          WORKSPACE_PATH: .
+          TARGET_PLATFORM: ${{ matrix.platform }}
+          DISABLE_SIGNING: true
+
+      - name: Collect installers
+        run: npm run build:editor:pack
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: opennoodl-${{ matrix.platform }}-${{ github.sha }}
+          path: publish
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
## Why

`nightly.yml` has a `cron: '0 3 * * *'` schedule but has **never run and never could**. GitHub registers `schedule:` triggers only from the repository's *default* branch, and the workflow existed only on `cline-dev`. The file has to be on `main` for the cron to exist at all.

## Why it also needs the ref pin

Moving the file alone would make it worse than inert. `actions/checkout` defaults to the branch the workflow ran from, and `main` does not contain `.github/actions/setup` — so a default checkout would fail at that step every single night, mailing a failure daily and proving nothing except that the alarm works.

So the checkout is pinned: **the schedule comes from `main`, the tree under test comes from `cline-dev`.** The ref is a `workflow_dispatch` input defaulting to `cline-dev`, so a one-off packaging check against any branch or SHA needs no edit.

Remove the pin when `cline-dev` merges to `main`, or when `main` is retired.

## Scope

One file. Otherwise byte-identical to the `cline-dev` copy, deliberately — a second gratuitous difference between the two copies would be a maintenance trap. Nothing else on `main` is touched, and no product code is involved.

## Note on the required checks

`main` requires 6 status checks (Typecheck, Lint, Test (editor), Test (platform-node), Build, Check build artefacts). This PR adds a workflow file and changes no code, so any failure here is a pre-existing property of the year-old `main` tree rather than something this change introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)